### PR TITLE
Update LibSSL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ENV DHAUTORECONF_VERSION=20
 ENV LIBZ_VERSION=1.2.13.dfsg
 # renovate: datasource=repology depName=debian_12/gettext versioning=loose
 ENV GETTEXT_VERSION=0.21-12
-ENV LIBSSL_VERSION=3.0.14-1~deb12u1
+ENV LIBSSL_VERSION=3.0.14-1~deb12u2
 # renovate: datasource=repology depName=debian_12/curl versioning=loose
 ENV LIBCURLDEV_VERSION=7.88.1-10+deb12u7
 # renovate: datasource=repology depName=debian_12/libexpat1-dev versioning=loose


### PR DESCRIPTION
Update LibSSL to latest patch level. Package for older version is no longer available.