### PR TITLE
Update libexpat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,7 @@ ENV GETTEXT_VERSION=0.21-12
 ENV LIBSSL_VERSION=3.0.14-1~deb12u2
 # renovate: datasource=repology depName=debian_12/curl versioning=loose
 ENV LIBCURLDEV_VERSION=7.88.1-10+deb12u7
-# renovate: datasource=repology depName=debian_12/libexpat1-dev versioning=loose
-ENV LIBEXPAT_VERSION=2.5.0-1
+ENV LIBEXPAT_VERSION=2.5.0-1+deb12u1
 
 # Download and extract Git source code
 ADD https://github.com/git/git/archive/refs/tags/v${GIT_VERSION}.tar.gz /tmp/git.tar.gz


### PR DESCRIPTION
Manually update version of `libexpat-dev` package, and remove Renovate instruction since it no longer seems to be listed on Repology.