### PR TITLE
Update libssl-dev to 3.0.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ENV DHAUTORECONF_VERSION=20
 ENV LIBZ_VERSION=1.2.13.dfsg
 # renovate: datasource=repology depName=debian_12/gettext versioning=loose
 ENV GETTEXT_VERSION=0.21-12
-ENV LIBSSL_VERSION=3.0.14-1~deb12u2
+ENV LIBSSL_VERSION=3.0.15-1~deb12u1
 # renovate: datasource=repology depName=debian_12/curl versioning=loose
 ENV LIBCURLDEV_VERSION=7.88.1-10+deb12u8
 ENV LIBEXPAT_VERSION=2.5.0-1+deb12u1


### PR DESCRIPTION
Updates `libssl-dev` to `3.0.15-1~deb12u1`
The package is required to build Git from sources.